### PR TITLE
Base64Encoded, OnshapeDocument, javadocs

### DIFF
--- a/onshape-java/api-base/pom.xml
+++ b/onshape-java/api-base/pom.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.onshape</groupId>
     <artifactId>api-base</artifactId>
-    <version>0.0.1</version>
     <packaging>jar</packaging>
+    <parent>
+        <groupId>com.onshape</groupId>
+        <artifactId>onshape-java</artifactId>
+        <version>0.0.1</version>
+    </parent>
     <dependencies>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
@@ -44,19 +47,12 @@
         <dependency>
             <groupId>org.hashids</groupId>
             <artifactId>hashids</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.nanohttpd</groupId>
             <artifactId>nanohttpd</artifactId>
             <version>2.3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-            <type>jar</type>
         </dependency>
     </dependencies>
     <properties>
@@ -64,4 +60,18 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
@@ -146,7 +146,7 @@ public class BaseClient {
     }
 
     /**
-     * Get the time at which the OAuth token was received
+     * Get the time at which the OAuth token was received.
      *
      * @return Date token received
      */
@@ -155,13 +155,14 @@ public class BaseClient {
     }
 
     /**
-     * Set an access code received from an OAuth request
+     * Set an access code received from an OAuth request.
      *
      * @param code Code returned from server
      * @param clientId Client id of application
      * @param clientSecret Client secret of application
      * @param redirectURI URI to redirect to after authentication
-     * @throws com.onshape.api.exceptions.OnshapeException
+     * @throws com.onshape.api.exceptions.OnshapeException On HTTP or
+     * serialization error.
      */
     public void setOAuthAccessCode(String code, String clientId, String clientSecret, String redirectURI) throws OnshapeException {
         WebTarget target = client.target("https://oauth.onshape.com/oauth/token");
@@ -218,7 +219,7 @@ public class BaseClient {
     }
 
     /**
-     * Performs the http call and transforms the result to the required class
+     * Performs the HTTP call and transforms the result to the required class.
      *
      * @param <T> Return type
      * @param method HTTP method
@@ -228,7 +229,8 @@ public class BaseClient {
      * @param queryParameters Map of query parameters
      * @param type Return type
      * @return Response object
-     * @throws com.onshape.api.exceptions.OnshapeException
+     * @throws com.onshape.api.exceptions.OnshapeException On HTTP or
+     * serialization error.
      */
     public final <T> T call(String method, String url, Object payload, Map<String, Object> urlParameters, Map<String, Object> queryParameters, Class<T> type) throws OnshapeException {
         Response response = call(method, url, payload, urlParameters, queryParameters);
@@ -259,7 +261,7 @@ public class BaseClient {
                         }
                         fos.flush();
                     }
-                    return (T) f;
+                    return type.cast(f);
                 } catch (IOException ex) {
                     throw new OnshapeException("Error while copying to local file", ex);
                 }
@@ -339,10 +341,10 @@ public class BaseClient {
     }
 
     /**
-     * Utility method to construct a Map from a varargs array of Objects
+     * Utility method to construct a Map from a varargs array of Objects.
      *
-     * @param objs Array of name-value pairs
-     * @return Map
+     * @param objs Array of name-value pairs.
+     * @return Map A map containing the names and values as keys and values.
      */
     public final Map<String, Object> buildMap(Object... objs) {
         Map<String, Object> out = new LinkedHashMap<>();

--- a/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
@@ -357,9 +357,15 @@ public class BaseClient {
     URI buildURI(String path, Map<String, Object> urlParameters, Map<String, Object> queryParameters) {
         UriBuilder uriBuilder;
         if (path.startsWith("/")) {
-            uriBuilder = UriBuilder.fromUri(baseURL + path.replaceAll(":([^\\/:]+)", "{$1}").replace("[wvm]", "{wvmType}"));
+            uriBuilder = UriBuilder.fromUri(baseURL + path
+                    .replaceAll(":([^\\/:]+)", "{$1}")
+                    .replace("[wvm]", "{wvmType}")
+                    .replace("[wv]", "{wvType}"));
         } else {
-            uriBuilder = UriBuilder.fromUri(path.replaceAll(":([^\\/:]+)", "{$1}").replace("[wvm]", "{wvmType}"));
+            uriBuilder = UriBuilder.fromUri(path
+                    .replaceAll(":([^\\/:]+)", "{$1}")
+                    .replace("[wvm]", "{wvmType}")
+                    .replace("[wv]", "{wvType}"));
         }
         queryParameters.entrySet().stream().filter((queryParameter) -> (queryParameter.getValue() != null))
                 .forEachOrdered((queryParameter) -> {

--- a/onshape-java/api-base/src/main/java/com/onshape/api/desktop/OnshapeDesktop.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/desktop/OnshapeDesktop.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
 /**
+ * Utility class for desktop based applications to launch Onshape client.
  *
  * @author Peter Harman peter.harman@cae.tech
  */
@@ -52,19 +53,21 @@ public class OnshapeDesktop {
     private static Server server;
 
     /**
+     * Creates a new instance with given application id.
      *
-     * @param clientId
-     * @param clientSecret
+     * @param clientId Client ID of application.
+     * @param clientSecret Client secret of application.
      */
     public OnshapeDesktop(String clientId, String clientSecret) {
         this(clientId, clientSecret, 6789);
     }
 
     /**
+     * Creates a new instance with given application id and port.
      *
-     * @param clientId
-     * @param clientSecret
-     * @param port
+     * @param clientId Client ID of application.
+     * @param clientSecret Client secret of application.
+     * @param port Network port to use for HTTP server.
      */
     public OnshapeDesktop(String clientId, String clientSecret, int port) {
         this.clientId = clientId;
@@ -73,19 +76,24 @@ public class OnshapeDesktop {
     }
 
     /**
+     * Launches browser-based login and sets credentials on the given Onshape
+     * client instance.
      *
-     * @param client
-     * @throws OnshapeException
+     * @param client An Onshape API client instance.
+     * @throws OnshapeException On HTTP, authentication, or serialization,
+     * error.
      */
     public void setupClient(BaseClient client) throws OnshapeException {
         client.setOAuthAccessCode(getAccessCodeFromBrowser(), clientId, clientSecret, "http://localhost:" + Integer.toString(port));
     }
 
     /**
+     * Applies previously obtained OAuth token to the given Onshape client
+     * instance.
      *
-     * @param client
-     * @param token
-     * @param tokenReceived
+     * @param client An Onshape API client instance.
+     * @param token An OAuth token previously obtained.
+     * @param tokenReceived The time at which the token was obtained.
      */
     public void setupClient(BaseClient client, OAuthTokenResponse token, Date tokenReceived) {
         client.setOAuthTokenResponse(token, tokenReceived, clientId, clientSecret);

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/Base64Encoded.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/Base64Encoded.java
@@ -1,7 +1,25 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * The MIT License
+ *
+ * Copyright 2018 Onshape Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 package com.onshape.api.types;
 

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/Base64Encoded.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/Base64Encoded.java
@@ -1,0 +1,95 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.onshape.api.types;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.onshape.api.types.Base64Encoded.Base64EncodedDeserializer;
+import com.onshape.api.types.Base64Encoded.Base64EncodedSerializer;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * Represents binary data encoded as Base64. This is serialized as a String in
+ * JSON.
+ *
+ * @author Peter Harman peter.harman@cae.tech
+ */
+@JsonSerialize(using = Base64EncodedSerializer.class)
+@JsonDeserialize(using = Base64EncodedDeserializer.class)
+public class Base64Encoded {
+
+    private final String base64String;
+
+    public Base64Encoded(byte[] data) {
+        this.base64String = Base64.getEncoder().encodeToString(data);
+    }
+
+    public Base64Encoded(String base64String) {
+        this.base64String = base64String;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 79 * hash + Objects.hashCode(this.base64String);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Base64Encoded other = (Base64Encoded) obj;
+        return Objects.equals(this.base64String, other.base64String);
+    }
+
+    @Override
+    public String toString() {
+        return base64String;
+    }
+
+    public String getBase64String() {
+        return base64String;
+    }
+
+    public byte[] getData() {
+        return Base64.getDecoder().decode(base64String);
+    }
+
+    static class Base64EncodedSerializer extends JsonSerializer<Base64Encoded> {
+
+        @Override
+        public void serialize(Base64Encoded t, JsonGenerator jg, SerializerProvider sp) throws IOException, JsonProcessingException {
+            jg.writeString(t.getBase64String());
+        }
+
+    }
+
+    static class Base64EncodedDeserializer extends JsonDeserializer<Base64Encoded> {
+
+        @Override
+        public Base64Encoded deserialize(JsonParser jp, DeserializationContext dc) throws IOException, JsonProcessingException {
+            return new Base64Encoded(jp.getText());
+        }
+
+    }
+}

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/OnshapeDocument.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/OnshapeDocument.java
@@ -1,0 +1,136 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Onshape Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.onshape.api.types;
+
+import com.onshape.api.exceptions.OnshapeException;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Represents a document in the Onshape web application, enabling documents to
+ * be selected in the API client by copying URL.
+ *
+ * @author Peter Harman peter.harman@cae.tech
+ */
+public class OnshapeDocument {
+
+    private static final Pattern PATTERN = Pattern.compile("^https:\\/\\/cad\\.onshape\\.com\\/documents\\/([0-9a-z]+)\\/w\\/([0-9a-z]+)\\/e\\/([0-9a-z]+)$");
+    private final String documentId;
+    private final String workspaceId;
+    private final String elementId;
+
+    /**
+     * Parse the given URL to determine document id, workspace id, and element
+     * id.
+     *
+     * @param url A URL from the Onshape web application.
+     * @throws OnshapeException If the URL cannot be parsed.
+     */
+    public OnshapeDocument(String url) throws OnshapeException {
+        Matcher matcher = PATTERN.matcher(url.trim());
+        if (matcher.find()) {
+            throw new OnshapeException("URL is not a valid Onshape document URL: " + url);
+        }
+        this.documentId = matcher.group(1);
+        this.workspaceId = matcher.group(2);
+        this.elementId = matcher.group(3);
+    }
+
+    /**
+     * Create a new instance from a document id, workspace id, and element id.
+     *
+     * @param documentId Document id.
+     * @param workspaceId Workspace id.
+     * @param elementId Element id.
+     */
+    public OnshapeDocument(String documentId, String workspaceId, String elementId) {
+        this.documentId = documentId;
+        this.workspaceId = workspaceId;
+        this.elementId = elementId;
+    }
+
+    /**
+     * Get the document id.
+     *
+     * @return Document id.
+     */
+    public String getDocumentId() {
+        return documentId;
+    }
+
+    /**
+     * Get the workspace id.
+     *
+     * @return Workspace id.
+     */
+    public String getWorkspaceId() {
+        return workspaceId;
+    }
+
+    /**
+     * Get the element id.
+     *
+     * @return Element id.
+     */
+    public String getElementId() {
+        return elementId;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 37 * hash + Objects.hashCode(this.documentId);
+        hash = 37 * hash + Objects.hashCode(this.workspaceId);
+        hash = 37 * hash + Objects.hashCode(this.elementId);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final OnshapeDocument other = (OnshapeDocument) obj;
+        if (!Objects.equals(this.documentId, other.documentId)) {
+            return false;
+        }
+        if (!Objects.equals(this.workspaceId, other.workspaceId)) {
+            return false;
+        }
+        return Objects.equals(this.elementId, other.elementId);
+    }
+
+    @Override
+    public String toString() {
+        return "https://cad.onshape.com/documents/" + documentId + "/w/" + workspaceId + "/e/" + elementId;
+    }
+
+}

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/WV.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/WV.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Onshape Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.onshape.api.types;
+
+/**
+ * Enumeration to choose whether identifier represents Workspace or Version.
+ *
+ * @author Peter Harman peter.harman@cae.tech
+ */
+public enum WV {
+    Workspace,
+    Version;
+
+    @Override
+    public String toString() {
+        return name().substring(0, 1).toLowerCase();
+    }
+
+}

--- a/onshape-java/api-generator/pom.xml
+++ b/onshape-java/api-generator/pom.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.onshape</groupId>
     <artifactId>api-generator</artifactId>
-    <version>0.0.1</version>
     <packaging>jar</packaging>
+    <parent>
+        <groupId>com.onshape</groupId>
+        <artifactId>onshape-java</artifactId>
+        <version>0.0.1</version>
+    </parent>
     <organization>
         <name>Onshape Inc</name>
         <url>http://www.onshape.com</url>
@@ -51,12 +54,6 @@
             <version>1.1.0.Final</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
             <version>2.23.1</version>
@@ -71,11 +68,30 @@
             <artifactId>compiler</artifactId>
             <version>0.9.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <parentdir>${project.basedir}${file.separator}..</parentdir>
     </properties>
     <build>
         <plugins>
@@ -97,6 +113,48 @@
                         <argument>${basedir}</argument>
                     </arguments>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>copy-api-base</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <copydir src="${parentdir}/api-base/src" dest="${project.basedir}/target/generated/src"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>build-generated</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <pom>${project.basedir}/target/generated/pom.xml</pom>
+                            <goals>install javadoc:javadoc</goals>
+                            <streamLogs>true</streamLogs>
+                            <showErrors>true</showErrors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
             </plugin>
         </plugins>
     </build>

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
@@ -146,6 +146,14 @@ public class JavaEndpointTarget extends EndpointTarget {
                     callBuilder.addParameter(ClassName.get("com.onshape.api.types", "WVM"), "wvmType");
                     javadoc.append("\n@param wvmType Type of Workspace, Version or Microversion\n");
                     i++;
+                } else if ("wv".equals(name)) {
+                    if (i > 0) {
+                        callStatement.append(", ");
+                    }
+                    callStatement.append("\"wvType\", wvType");
+                    callBuilder.addParameter(ClassName.get("com.onshape.api.types", "WV"), "wvType");
+                    javadoc.append("\n@param wvType Type of Workspace or Version\n");
+                    i++;
                 }
                 Class<?> type = JavaLibraryTarget.guessClass(field.getType());
                 if (i > 0) {

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaGroupTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaGroupTarget.java
@@ -37,7 +37,8 @@ import java.io.IOException;
 import javax.lang.model.element.Modifier;
 
 /**
- *
+ * Generates client code for one API group in Java.
+ * 
  * @author Peter Harman peter.harman@cae.tech
  */
 public class JavaGroupTarget extends GroupTarget {
@@ -52,11 +53,6 @@ public class JavaGroupTarget extends GroupTarget {
     @Override
     public EndpointTarget endpoint(Endpoint endpoint) {
         return new JavaEndpointTarget(this, endpoint);
-    }
-
-    @Override
-    public void start() {
-        //System.out.println(getGroup().getGroup());
     }
 
     @Override

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaLibraryTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaLibraryTarget.java
@@ -27,7 +27,6 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import com.google.common.io.CharStreams;
-import com.google.common.io.Files;
 import com.onshape.api.base.BaseClient;
 import com.onshape.api.types.OnshapeVersion;
 import com.onshape.api.generator.targets.GroupTarget;
@@ -51,8 +50,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.lang.model.element.Modifier;
 
 /**

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaLibraryTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaLibraryTarget.java
@@ -56,7 +56,8 @@ import java.util.logging.Logger;
 import javax.lang.model.element.Modifier;
 
 /**
- *
+ * Generates a client library in Java.
+ * 
  * @author Peter Harman peter.harman@cae.tech
  */
 public class JavaLibraryTarget extends LibraryTarget {

--- a/onshape-java/pom.xml
+++ b/onshape-java/pom.xml
@@ -11,47 +11,6 @@
     </modules>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.jupiter.version>5.3.1</junit.jupiter.version>
     </properties>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
-                <executions>
-                    <execution>
-                        <id>copy-api-base</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <copydir src="api-base/src" dest="api-generator/target/generated/src"/>
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-invoker-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>build-generated</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <pom>api-generator/target/generated/pom.xml</pom>
-                            <goals>install</goals>
-                            <streamLogs>true</streamLogs>
-                            <showErrors>true</showErrors>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
* Added support for endpoints with a [wv] option (previously [wvm] option was supported).
* Added Base64Encoded type so that data encoded as Base64 can be deserialized to this and immediately decoded to a byte[]
* Added OnshapeDocument type that allows a URL to be copied from the Onshape web application and used directly to call many of the endpoints
* Improved Javadoc