### PR TITLE
Credentials via .onshape-build file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /onshape-java/api-base/target/
 /onshape-java/api-generator/target/
 /onshape-java/target/
+.onshape-build

--- a/onshape-java/README.md
+++ b/onshape-java/README.md
@@ -15,9 +15,14 @@ The following tools are required to run the API generator:
 
 In order to access the Onshape API, API access keys are required. See [Onshape Dev Portal](https://dev-portal.onshape.com/keys) to generate or manage API keys.
 
-These are provided in environment variables:
-* ONSHAPE_API_ACCESSKEY - The access key
-* ONSHAPE_API_SECRETKEY - The secret key
+These are provided via a file called `.onshape-build` placed at the top-level of the working-copy of this git repository. The required contents of `.onshape-build`
+is a JSON object containing:
+```
+{
+  "onshape-api-accesskey": "<PUT YOUR ACCESS KEY HERE>",
+  "onshape-api-secretkey": "<PUT YOUR SECRET KEY HERE>"
+}
+```
 
 It is expected that the active user in Git has sufficient privileges to push to the required Github repository if a push is requested.
 

--- a/onshape-java/api-base/pom.xml
+++ b/onshape-java/api-base/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>nanohttpd</artifactId>
             <version>2.3.1</version>
         </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaLibraryTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaLibraryTarget.java
@@ -50,7 +50,6 @@ import java.io.Writer;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.lang.model.element.Modifier;

--- a/onshape-java/api-generator/src/main/resources/java/pom.xml
+++ b/onshape-java/api-generator/src/main/resources/java/pom.xml
@@ -75,6 +75,11 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Credentials are now to be supplied via JSON file called .onshape-build, placed at top of repo.
Also fixed errors due to missing javax.activation dependency.
