### PR TITLE
Add a boundary subtype to the entity media-type

### DIFF
--- a/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
@@ -71,6 +71,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.media.multipart.Boundary;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
@@ -380,9 +381,21 @@ public class BaseClient {
         URI uri = buildURI(url, urlParameters, queryParameters);
         // Create a WebTarget for the URI
         WebTarget target = client.target(uri);
-        Response response;
         Invocation.Builder invocationBuilder = target.request(jsonResponse ? MediaType.APPLICATION_JSON_TYPE : MediaType.APPLICATION_OCTET_STREAM_TYPE)
                 .header("Accept", jsonResponse ? "application/vnd.onshape.v1+json" : "application/vnd.onshape.v1+octet-stream");
+        // Set the content-type and build the entity
+        Entity entity;
+        switch (method.toUpperCase()) {
+            case "GET":
+            case "HEAD":
+            case "DELETE":
+                invocationBuilder.header("Content-Type", MediaType.APPLICATION_JSON_TYPE.toString());
+                entity = null;
+                break;
+            default:
+                entity = createEntity(payload, invocationBuilder);
+        }
+        // Add authentication headers, via either OAuth or API keys
         if (token != null) {
             if ((new Date().getTime() - tokenReceived.getTime()) / 1000 > token.getExpiresIn() * 0.9) {
                 try {
@@ -393,19 +406,11 @@ public class BaseClient {
             }
             invocationBuilder = invocationBuilder.header("Authorization", "Bearer " + token.getAccessToken());
         } else if (accessKey != null && secretKey != null) {
-            invocationBuilder = signature(invocationBuilder, uri, method);
+            invocationBuilder = signature(invocationBuilder, uri, method, entity == null ? MediaType.APPLICATION_JSON_TYPE : entity.getMediaType());
         }
-        switch (method.toUpperCase()) {
-            case "GET":
-            case "HEAD":
-            case "DELETE":
-                invocationBuilder.header("Content-Type", "application/json");
-                response = invocationBuilder.method(method.toUpperCase());
-                break;
-            default:
-                Entity entity = createEntity(payload, invocationBuilder);
-                response = invocationBuilder.method(method.toUpperCase(), entity);
-        }
+        // Perform the method call
+        Response response = entity == null ? invocationBuilder.method(method.toUpperCase()) : invocationBuilder.method(method.toUpperCase(), entity);
+        // Handle the response
         switch (response.getStatusInfo().getFamily()) {
             case SUCCESSFUL:
                 return response;
@@ -425,6 +430,7 @@ public class BaseClient {
      * @throws OnshapeException If fail to serialize successfully
      */
     Entity createEntity(Object payload, Invocation.Builder invocationBuilder) throws OnshapeException {
+        MediaType mediaType;
         Field fileField = null;
         for (Field field : payload.getClass().getDeclaredFields()) {
             if (File.class.equals(field.getType())) {
@@ -433,11 +439,11 @@ public class BaseClient {
         }
         // If no File, then return JSON entity
         if (fileField == null) {
-            invocationBuilder.header("Content-Type", "application/json");
-            return Entity.entity(payload, MediaType.APPLICATION_JSON_TYPE);
+            mediaType = MediaType.APPLICATION_JSON_TYPE;
+            invocationBuilder.header("Content-Type", mediaType.toString());
+            return Entity.entity(payload, mediaType);
         }
-        // Else create multipart entity
-        invocationBuilder.header("Content-Type", "multipart/form-data");
+        // Else create multipart entity        
         FormDataMultiPart multipart = new FormDataMultiPart();
         try {
             for (Field field : payload.getClass().getDeclaredFields()) {
@@ -453,7 +459,10 @@ public class BaseClient {
         }
         // Add an XSRF header: Not currently required by Onshape APIs
         //addXSRFHeader(invocationBuilder);
-        return Entity.entity(multipart, MediaType.MULTIPART_FORM_DATA_TYPE);
+        // Add a boundary subtype to the media-type, this will be used in the entity and signature (if using API keys)
+        mediaType = Boundary.addBoundary(MediaType.MULTIPART_FORM_DATA_TYPE);
+        invocationBuilder.header("Content-Type", mediaType.toString());
+        return Entity.entity(multipart, mediaType);
     }
 
     /**
@@ -541,12 +550,12 @@ public class BaseClient {
 
     private long count = 0L;
 
-    Invocation.Builder signature(Invocation.Builder builder, URI uri, String method) throws OnshapeException {
+    Invocation.Builder signature(Invocation.Builder builder, URI uri, String method, MediaType mediaType) throws OnshapeException {
         String date = getDateString();
         String onNonce = hashids.encode(new Date().getTime(), count++);
         String path = uri.getPath();
         String query = uri.getQuery() == null ? "" : uri.getQuery();
-        String str = (method + '\n' + onNonce + '\n' + date + '\n' + "application/json" + '\n'
+        String str = (method + '\n' + onNonce + '\n' + date + '\n' + mediaType.toString() + '\n'
                 + path + '\n' + query + '\n').toLowerCase();
         String auth = "On " + accessKey + ":HmacSHA256:" + encodeSignature(str);
         builder.header("Date", date);


### PR DESCRIPTION
Add a boundary subtype to the entity media-type, fixes issues with using API keys for multipart form uploads, as signature did not match actual media-type (https://github.com/onshape-public/java-client/issues/2)