### PR TITLE
Fix serialization issue and upgrade to Jackson 2.9.7

### DIFF
--- a/onshape-java/api-base/pom.xml
+++ b/onshape-java/api-base/pom.xml
@@ -37,12 +37,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.8.4</version>
+            <version>2.9.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.4</version>
+            <version>2.9.7</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
@@ -23,6 +23,7 @@
  */
 package com.onshape.api.generator.java;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
@@ -46,7 +47,6 @@ import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
-import com.squareup.javapoet.TypeVariableName;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -405,6 +405,7 @@ public class JavaEndpointTarget extends EndpointTarget {
             typeSpecBuilder.addMethod(MethodSpec.methodBuilder("getDocument")
                     .returns(ClassName.get(OnshapeDocument.class))
                     .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
+                    .addAnnotation(JsonIgnore.class)
                     .addStatement(documentBuilder.toString(), WVM.class)
                     .addJavadoc("Returns an OnshapeDocument object that can be used in subsequent calls to the related document\n@return The OnshapeDocument object.\n")
                     .build());

--- a/onshape-java/api-generator/src/main/resources/java/pom.xml
+++ b/onshape-java/api-generator/src/main/resources/java/pom.xml
@@ -40,12 +40,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.8.4</version>
+            <version>2.9.7</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.4</version>
+            <version>2.9.7</version>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>


### PR DESCRIPTION
The "getDocument" method was being incorrectly serialized by Jackson, so added a JsonIgnore annotation.
Upgraded Jackson to 2.9.7.