### PR TITLE
Added support for gzip compression for responses

### DIFF
--- a/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
@@ -112,6 +112,7 @@ public class BaseClient {
         jacksonProvider.setMapper(objectMapper);
         ClientConfig clientConfig = new ClientConfig(jacksonProvider);
         clientConfig.register(MultiPartFeature.class);
+        clientConfig.register(new CompressionReaderInterceptor());
         client = ClientBuilder.newClient(clientConfig);
         workingDir = new File(System.getProperty("java.io.tmpdir"));
         usingValidation = true;
@@ -407,6 +408,8 @@ public class BaseClient {
         WebTarget target = client.target(uri);
         Invocation.Builder invocationBuilder = target.request(jsonResponse ? MediaType.APPLICATION_JSON_TYPE : MediaType.APPLICATION_OCTET_STREAM_TYPE)
                 .header("Accept", jsonResponse ? "application/vnd.onshape.v1+json" : "application/vnd.onshape.v1+octet-stream");
+        // Accept gzip compressed responses
+        invocationBuilder.header("Accept-Encoding", "gzip");
         // Set the content-type and build the entity
         Entity entity;
         switch (method.toUpperCase()) {
@@ -648,7 +651,7 @@ public class BaseClient {
 
     /**
      * Fetches utility object for polling GET requests via this client.
-     * 
+     *
      * @return PollingHandler instance
      */
     public PollingHandler getPollingHandler() {

--- a/onshape-java/api-base/src/main/java/com/onshape/api/base/CompressionReaderInterceptor.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/base/CompressionReaderInterceptor.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 Onshape Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.onshape.api.base;
+
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.ReaderInterceptor;
+import javax.ws.rs.ext.ReaderInterceptorContext;
+
+/**
+ * Decompresses any entities compressed with gzip
+ * 
+ * @author Peter Harman peter.harman@cae.tech
+ */
+@Provider
+public class CompressionReaderInterceptor implements ReaderInterceptor {
+    
+    @Override
+    public Object aroundReadFrom(ReaderInterceptorContext context) throws IOException, WebApplicationException {
+        if (context.getHeaders().containsKey("Content-Encoding")
+                && context.getHeaders().get("Content-Encoding").contains("gzip")) {
+            context.setInputStream(new GZIPInputStream(context.getInputStream()));
+        }
+        return context.proceed();
+    }
+    
+}


### PR DESCRIPTION
Added support for gzip compression so that, where API methods support, download sizes are reduced.
See https://github.com/onshape-public/java-client/issues/8