### PR TITLE
Query-parameters, empty responses

### DIFF
--- a/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
@@ -315,6 +315,10 @@ public class BaseClient {
         }
         if (response.getMediaType().toString().startsWith(MediaType.APPLICATION_JSON)) {
             String stringEntity = response.readEntity(String.class);
+            // Special case: Return a String
+            if(String.class.equals(type)) {
+                return type.cast(stringEntity);
+            }
             // Special case: If it is an array, and the response type has a single array field, then read that
             try {
                 if (stringEntity.startsWith("[") && type.getDeclaredFields().length == 1 && type.getDeclaredFields()[0].getType().isArray()) {

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
@@ -271,7 +271,13 @@ public class JavaEndpointTarget extends EndpointTarget {
                     requestBuilder.addField(fieldBuilder.build());
                 } else {
                     callBuilder.addParameter(JavaLibraryTarget.getTypeName(type), JavaLibraryTarget.safeName(name));
+                    callBuilder2.addParameter(JavaLibraryTarget.getTypeName(type), JavaLibraryTarget.safeName(name));
                     javadoc.append("\n@param ")
+                            .append(JavaLibraryTarget.safeName(name)).append(" ")
+                            .append(Utilities.escape(field.getDescription()))
+                            .append(" (Default: ")
+                            .append(field.getDefaultValue()).append(")");
+                    javadoc2.append("\n@param ")
                             .append(JavaLibraryTarget.safeName(name)).append(" ")
                             .append(Utilities.escape(field.getDescription()))
                             .append(" (Default: ")
@@ -279,8 +285,10 @@ public class JavaEndpointTarget extends EndpointTarget {
                 }
                 if (i > 0) {
                     callStatement.append(", ");
+                    callStatement2.append(", ");
                 }
-                callStatement.append('"').append(name).append("\", ").append(name.replace('-', '_'));
+                callStatement.append('"').append(name).append("\", ").append(JavaLibraryTarget.safeName(name));
+                callStatement2.append('"').append(name).append("\", ").append(JavaLibraryTarget.safeName(name));
                 i++;
             }
         }


### PR DESCRIPTION
Fixed cases where query-parameters were not passed to HTTP call - see https://github.com/onshape-public/java-client/issues/9
Added ability to return a String of the entity in cases where it might not be deserializable (e.g. because it is empty - see https://github.com/onshape-public/java-client/issues/10