### PR TITLE
Added ability to get InputStream and headers from methods

### DIFF
--- a/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 import com.onshape.api.exceptions.OnshapeException;
 import com.onshape.api.types.Blob;
+import com.onshape.api.types.InputStreamWithHeaders;
 import com.onshape.api.types.OAuthTokenResponse;
 import com.onshape.api.types.OnshapeVersion;
 import java.io.File;
@@ -309,6 +310,10 @@ public class BaseClient {
         }
         // Call the HTTP method
         Response response = call(method, url, payload, urlParameters, queryParameters, jsonResponse);
+        // Return the raw stream and headers if requested
+        if (InputStreamWithHeaders.class.equals(type)) {
+            return type.cast(new InputStreamWithHeaders((InputStream) response.getEntity(), response.getHeaders()));
+        }
         // Deserialize the response
         if (response.getMediaType() == null) {
             if (type.getDeclaredFields().length == 0) {
@@ -358,6 +363,8 @@ public class BaseClient {
                     } catch (IOException ex) {
                         throw new OnshapeException("Error while copying to local file", ex);
                     }
+                } else if (InputStream.class.isAssignableFrom(type)) {
+                    return type.cast(input);
                 } else if (type.getDeclaredFields().length == 1) {
                     if (File.class.equals(type.getDeclaredFields()[0].getType())) {
                         try {

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/InputStreamWithHeaders.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/InputStreamWithHeaders.java
@@ -1,0 +1,117 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 Onshape Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.onshape.api.types;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+import javax.ws.rs.core.MultivaluedMap;
+
+/**
+ * Captures the InputStream from a response, together with the response headers
+ *
+ * @author Peter Harman peter.harman@cae.tech
+ */
+public class InputStreamWithHeaders {
+
+    private final InputStream inputStream;
+    private final MultivaluedMap<String, Object> headers;
+
+    public InputStreamWithHeaders(InputStream inputStream, MultivaluedMap<String, Object> headers) {
+        this.inputStream = inputStream;
+        this.headers = headers;
+    }
+
+    /**
+     * Returns the InputStream as received, which may or may not be gzip
+     * compressed.
+     *
+     * @return InputStream matching the Content-Type and Content-Encoding
+     */
+    public InputStream getInputStream() {
+        return inputStream;
+    }
+
+    /**
+     * Returns an InputStream, decompressing the raw InputStream if it had been
+     * gzip compressed.
+     *
+     * @return InputStream matching the Content-Type
+     * @throws java.io.IOException On error during decompression
+     */
+    public InputStream getDecompressedInputStream() throws IOException {
+        return "gzip".equals(getContentEncoding())
+                ? new GZIPInputStream(inputStream)
+                : inputStream;
+    }
+
+    /**
+     * Get the headers returned from Onshape
+     *
+     * @return MultivaluedMap of headers
+     */
+    public MultivaluedMap<String, Object> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * Get the value of a particular header
+     *
+     * @param header The name of the header of interest
+     * @return null if the header is not defined, an empty String if it is
+     * empty, or a String joining each header value with ','
+     */
+    public String getHeaderString(String header) {
+        List<Object> headerObjects = headers.get(header);
+        if (headerObjects == null) {
+            return null;
+        }
+        if (headerObjects.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(headerObjects.get(0).toString());
+        headerObjects.listIterator(1).forEachRemaining((obj) -> sb.append(',').append(obj.toString()));
+        return sb.toString();
+    }
+
+    /**
+     * Get the Content-Type of the returned InputStream
+     *
+     * @return A String of the Content-Type, or null if it is not defined
+     */
+    public String getContentType() {
+        return getHeaderString("Content-Type");
+    }
+
+    /**
+     * Get the Content-Encoding of the returned InputStream
+     *
+     * @return A String of the Content-Encoding, or null if it is not defined
+     */
+    public String getContentEncoding() {
+        return getHeaderString("Content-Encoding");
+    }
+
+}


### PR DESCRIPTION
See https://github.com/onshape-public/java-client/issues/17

Where a method downloads a file, being able to access the InputStream and headers allows this to be passed to another process without loading into memory.
