### PR TITLE
File upload bug

### DIFF
--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/AbstractResponseObject.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/AbstractResponseObject.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 Onshape Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.onshape.api.types;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Base class for response objects that captures unknown properties into a map
+ * 
+ * @author Peter Harman peter.harman@cae.tech
+ */
+public class AbstractResponseObject {
+
+    @JsonAnySetter
+    private final Map<String, Object> otherProperties = new HashMap<>();
+
+    @JsonAnyGetter
+    public final Map<String, Object> getOtherProperties() {
+        return otherProperties;
+    }
+
+}

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/JsonObjectOrArrayInputStream.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/JsonObjectOrArrayInputStream.java
@@ -1,0 +1,117 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 Onshape Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.onshape.api.types;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PushbackInputStream;
+import java.io.SequenceInputStream;
+
+/**
+ * InputStream that modifies a wrapped stream in the case where an array of JSON
+ * is returned but is to be deserialized to an array field within an object.
+ * 
+ * @author Peter Harman peter.harman@cae.tech
+ */
+public class JsonObjectOrArrayInputStream extends InputStream {
+
+    private final InputStream stream;
+
+    public JsonObjectOrArrayInputStream(Class<?> serializationType, InputStream stream) throws IOException {
+        // Create a pushback stream so we can check and pushback the first character
+        PushbackInputStream pushbackStream = new PushbackInputStream(stream, 1);
+        int first = pushbackStream.read();
+        pushbackStream.unread(first);
+        // Check the first character in the stream
+        boolean streamIsArray = first == '[';
+        // Check the type we are deserializing to
+        boolean typeIsArray = serializationType.isArray();
+        boolean typeContainsArray = !typeIsArray
+                && serializationType.getDeclaredFields().length == 1
+                && serializationType.getDeclaredFields()[0].getType().isArray();
+        // Stream is array but type isn't or vice versa
+        if (streamIsArray && !(typeIsArray || typeContainsArray)) {
+            throw new IOException("Attempting to map array response to object type");
+        }
+        if (!streamIsArray && typeIsArray) {
+            throw new IOException("Attempting to map object response to array type");
+        }
+        if (streamIsArray && typeContainsArray) {
+            // Stream modified to wrap array element
+            String fieldName = serializationType.getDeclaredFields()[0].getName();
+            this.stream = new SequenceInputStream(new ByteArrayInputStream(("{\"" + fieldName + "\":").getBytes("UTF-8")),
+                    new SequenceInputStream(pushbackStream, new ByteArrayInputStream(("}").getBytes("UTF-8"))));
+        } else {
+            // Stream should be returned as-is
+            this.stream = pushbackStream;
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        return stream.read();
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        return stream.read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return stream.read(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        return stream.skip(n);
+    }
+
+    @Override
+    public int available() throws IOException {
+        return stream.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        stream.close();
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        stream.mark(readlimit);
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        stream.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return stream.markSupported();
+    }
+
+}

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/OnshapeDocument.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/OnshapeDocument.java
@@ -260,10 +260,7 @@ public class OnshapeDocument {
         if (!Objects.equals(this.elementId, other.elementId)) {
             return false;
         }
-        if (this.wvm != other.wvm) {
-            return false;
-        }
-        return true;
+        return this.wvm == other.wvm;
     }
 
     @Override

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/ResponseWithDocument.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/ResponseWithDocument.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 Onshape Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.onshape.api.types;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * A response object that references an Onshape document
+ *
+ * @author Peter Harman peter.harman@cae.tech
+ */
+public interface ResponseWithDocument {
+
+    /**
+     * Returns an OnshapeDocument object that can be used in subsequent calls to
+     * the related document
+     *
+     * @return The OnshapeDocument object.
+     */
+    @JsonIgnore
+    public OnshapeDocument getDocument();
+}

--- a/onshape-java/api-generator/nbactions.xml
+++ b/onshape-java/api-generator/nbactions.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<actions>
+        <action>
+            <actionName>run</actionName>
+            <packagings>
+                <packaging>jar</packaging>
+            </packagings>
+            <goals>
+                <goal>process-classes</goal>
+                <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>
+            </goals>
+            <properties>
+                <exec.args>-classpath %classpath com.onshape.api.generator.Generator ./target false</exec.args>
+                <exec.executable>java</exec.executable>
+            </properties>
+        </action>
+        <action>
+            <actionName>debug</actionName>
+            <packagings>
+                <packaging>jar</packaging>
+            </packagings>
+            <goals>
+                <goal>process-classes</goal>
+                <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>
+            </goals>
+            <properties>
+                <exec.args>-Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath com.onshape.api.generator.Generator ./target false</exec.args>
+                <exec.executable>java</exec.executable>
+                <jpda.listen>true</jpda.listen>
+            </properties>
+        </action>
+        <action>
+            <actionName>profile</actionName>
+            <packagings>
+                <packaging>jar</packaging>
+            </packagings>
+            <goals>
+                <goal>process-classes</goal>
+                <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>
+            </goals>
+            <properties>
+                <exec.args>-classpath %classpath com.onshape.api.generator.Generator ./target false</exec.args>
+                <exec.executable>java</exec.executable>
+            </properties>
+        </action>
+    </actions>

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/Generator.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/Generator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,9 +105,16 @@ public class Generator {
         OnshapeVersion buildVersion = client.version();
         Group[] apiGroups = client.call("GET", "/endpoints", null, new HashMap<>(), new HashMap<>(), Group[].class);
         Group[] augmentGroups;
+        Group[] deleteGroups;
+        try {
+            deleteGroups = new ObjectMapper().readValue(new File(targetDir, "classes/endpoints.delete.json"), Group[].class);
+            apiGroups = Group.merge(apiGroups, deleteGroups, false);
+        } catch (IOException ex) {
+            System.out.println("No endpoints.delete.json file or not successfully read");
+        }
         try {
             augmentGroups = new ObjectMapper().readValue(new File(targetDir, "classes/endpoints.augment.json"), Group[].class);
-            apiGroups = Group.merge(apiGroups, augmentGroups);
+            apiGroups = Group.merge(apiGroups, augmentGroups, true);
         } catch (IOException ex) {
             System.out.println("Using endpoints from server as no endpoints.augment.json file or not successfully read");
         }

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/Utilities.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/Utilities.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/exceptions/GeneratorException.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/exceptions/GeneratorException.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,6 @@
 package com.onshape.api.generator.java;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -34,6 +33,7 @@ import com.onshape.api.generator.Utilities;
 import com.onshape.api.generator.exceptions.GeneratorException;
 import com.onshape.api.generator.model.Endpoint;
 import com.onshape.api.generator.model.Field;
+import com.onshape.api.types.AbstractResponseObject;
 import com.onshape.api.types.Base64Encoded;
 import com.onshape.api.types.Blob;
 import com.onshape.api.types.InputStreamWithHeaders;
@@ -96,7 +96,7 @@ public class JavaEndpointTarget extends EndpointTarget {
         // Create a new class for the request object
         String newClassName = getGroupTarget().getGroup().getGroup() + Utilities.toCamelCase(methodName) + "Request";
         TypeSpec.Builder requestBuilder = TypeSpec.classBuilder(newClassName)
-                .addJavadoc("Request object for " + methodName + " API endpoint.\n&copy; 2018 Onshape Inc.\n")
+                .addJavadoc("Request object for " + methodName + " API endpoint.\n&copy; 2018-Present Onshape Inc.\n")
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
         if (deprecated) {
             requestBuilder.addAnnotation(Deprecated.class);
@@ -427,9 +427,7 @@ public class JavaEndpointTarget extends EndpointTarget {
         }
         TypeSpec.Builder typeSpecBuilder = TypeSpec.classBuilder(typeName)
                 .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
-                .addJavadoc("Object used in calls to " + getEndpoint().getName() + " API endpoint.\n&copy; 2018 Onshape Inc.\n")
-                .addAnnotation(AnnotationSpec.builder(JsonIgnoreProperties.class)
-                        .addMember("ignoreUnknown", "$L", Boolean.TRUE).build());
+                .addJavadoc("Object used in calls to " + getEndpoint().getName() + " API endpoint.\n&copy; 2018-Present Onshape Inc.\n");
         Set<String> hasDocumentFields = new HashSet<>();
         for (Map.Entry<Field, TypeName> field : types.entrySet()) {
             String javadoc = field.getKey().getDescription() == null ? "" : field.getKey().getDescription().replace("$", "");
@@ -464,7 +462,10 @@ public class JavaEndpointTarget extends EndpointTarget {
                     .addJavadoc("Returns an OnshapeDocument object that can be used in subsequent calls to the related document\n@return The OnshapeDocument object.\n")
                     .build());
         }
-        addToString(typeSpecBuilder);
+        if (!builder) {
+            typeSpecBuilder = addUnknownPropertiesHandler(typeSpecBuilder);
+        }
+        typeSpecBuilder = addToString(typeSpecBuilder);
         write(packageName, typeSpecBuilder, false);
         return ClassName.get(packageName, typeName);
     }
@@ -475,8 +476,7 @@ public class JavaEndpointTarget extends EndpointTarget {
         String newClassName = groupName + Utilities.toCamelCase(getEndpoint().getName()) + "Response";
         boolean deprecated = getEndpoint().getName().contains("Deprecated");
         TypeSpec.Builder responseBuilder = TypeSpec.classBuilder(newClassName)
-                .addJavadoc("Response object for " + getEndpoint().getName() + " API endpoint.\n&copy; 2018 Onshape Inc.\n")
-                .addAnnotation(AnnotationSpec.builder(JsonIgnoreProperties.class).addMember("ignoreUnknown", "$L", Boolean.TRUE).build())
+                .addJavadoc("Response object for " + getEndpoint().getName() + " API endpoint.\n&copy; 2018-Present Onshape Inc.\n")
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
         if (deprecated) {
             responseBuilder.addAnnotation(Deprecated.class);
@@ -518,9 +518,17 @@ public class JavaEndpointTarget extends EndpointTarget {
                             fieldType = createLocalType("com.onshape.api.responses", name, typeName, name + ".", allResponseFields, false);
                         }
                     } else if (t.equals(Object[].class)) {
-                        String typeName = newClassName + Utilities.toCamelCase(name);
-                        TypeName ref = createLocalType("com.onshape.api.responses", name, typeName, name + ".", allResponseFields, false);
-                        fieldType = ArrayTypeName.of(ref);
+                        if (allResponseFields.stream().map((f) -> f.getField()).anyMatch((n) -> n.equals(name + ".0.key"))) {
+                            // It is a map, create a value type
+                            String valueTypeName = newClassName + Utilities.toCamelCase(name) + "Value";
+                            TypeName valueType = createLocalType("com.onshape.api.responses", name, valueTypeName, name + ".0.key.", allResponseFields, false);
+                            TypeName ref = ParameterizedTypeName.get(ClassName.get(Map.class), ClassName.get(String.class), valueType);
+                            fieldType = ArrayTypeName.of(ref);
+                        } else {
+                            String typeName = newClassName + Utilities.toCamelCase(name);
+                            TypeName ref = createLocalType("com.onshape.api.responses", name, typeName, name + ".", allResponseFields, false);
+                            fieldType = ArrayTypeName.of(ref);
+                        }
                     } else if (field.getField().equals("file") && t.equals(Base64Encoded.class) && allResponseFields.size() == 1) {
                         // An object with single field called "file" is treated differently by the client, as the response is just the File content
                         fieldType = JavaLibraryTarget.getTypeName(Blob.class);
@@ -599,6 +607,7 @@ public class JavaEndpointTarget extends EndpointTarget {
                     .build());
         }
         responseBuilder = GetterSpec.forType(responseBuilder).build();
+        responseBuilder = addUnknownPropertiesHandler(responseBuilder);
         addToString(responseBuilder);
         write("com.onshape.api.responses", responseBuilder, false);
         return hasFileField;
@@ -610,6 +619,10 @@ public class JavaEndpointTarget extends EndpointTarget {
                 .returns(TypeName.get(String.class))
                 .addAnnotation(Override.class)
                 .addStatement("return $T.toString(this)", ClassName.get("com.onshape.api", "Onshape")).build());
+    }
+
+    TypeSpec.Builder addUnknownPropertiesHandler(TypeSpec.Builder builder) {
+        return builder.superclass(ClassName.get(AbstractResponseObject.class));
     }
 
     String getFieldName(Field field) {

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
@@ -38,6 +38,7 @@ import com.onshape.api.types.Base64Encoded;
 import com.onshape.api.types.Blob;
 import com.onshape.api.types.InputStreamWithHeaders;
 import com.onshape.api.types.OnshapeDocument;
+import com.onshape.api.types.ResponseWithDocument;
 import com.onshape.api.types.WVM;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ArrayTypeName;
@@ -454,13 +455,15 @@ public class JavaEndpointTarget extends EndpointTarget {
             documentBuilder.append(hasDocumentFields.contains("documentVersion") ? "documentVersion, " : "null, ");
             documentBuilder.append(hasDocumentFields.contains("documentMicroversion") ? "documentMicroversion, " : "null, ");
             documentBuilder.append(hasDocumentFields.contains("elementId") ? "elementId)" : "null)");
-            typeSpecBuilder.addMethod(MethodSpec.methodBuilder("getDocument")
-                    .returns(ClassName.get(OnshapeDocument.class))
-                    .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
-                    .addAnnotation(JsonIgnore.class)
-                    .addStatement(documentBuilder.toString(), WVM.class)
-                    .addJavadoc("Returns an OnshapeDocument object that can be used in subsequent calls to the related document\n@return The OnshapeDocument object.\n")
-                    .build());
+            typeSpecBuilder.addSuperinterface(ClassName.get(ResponseWithDocument.class))
+                    .addMethod(MethodSpec.methodBuilder("getDocument")
+                            .returns(ClassName.get(OnshapeDocument.class))
+                            .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
+                            .addAnnotation(JsonIgnore.class)
+                            .addAnnotation(Override.class)
+                            .addStatement(documentBuilder.toString(), WVM.class)
+                            .addJavadoc("Returns an OnshapeDocument object that can be used in subsequent calls to the related document\n@return The OnshapeDocument object.\n")
+                            .build());
         }
         if (!builder) {
             typeSpecBuilder = addUnknownPropertiesHandler(typeSpecBuilder);
@@ -598,13 +601,15 @@ public class JavaEndpointTarget extends EndpointTarget {
             documentBuilder.append(hasDocumentFields.contains("documentVersion") ? "documentVersion, " : "null, ");
             documentBuilder.append(hasDocumentFields.contains("documentMicroversion") ? "documentMicroversion, " : "null, ");
             documentBuilder.append(hasDocumentFields.contains("elementId") ? "elementId)" : "null)");
-            responseBuilder.addMethod(MethodSpec.methodBuilder("getDocument")
-                    .returns(ClassName.get(OnshapeDocument.class))
-                    .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
-                    .addAnnotation(JsonIgnore.class)
-                    .addStatement(documentBuilder.toString(), WVM.class)
-                    .addJavadoc("Returns an OnshapeDocument object that can be used in subsequent calls to the related document\n@return The OnshapeDocument object.\n")
-                    .build());
+            responseBuilder.addSuperinterface(ClassName.get(ResponseWithDocument.class))
+                    .addMethod(MethodSpec.methodBuilder("getDocument")
+                            .returns(ClassName.get(OnshapeDocument.class))
+                            .addModifiers(Modifier.FINAL, Modifier.PUBLIC)
+                            .addAnnotation(JsonIgnore.class)
+                            .addAnnotation(Override.class)
+                            .addStatement(documentBuilder.toString(), WVM.class)
+                            .addJavadoc("Returns an OnshapeDocument object that can be used in subsequent calls to the related document\n@return The OnshapeDocument object.\n")
+                            .build());
         }
         responseBuilder = GetterSpec.forType(responseBuilder).build();
         responseBuilder = addUnknownPropertiesHandler(responseBuilder);

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaGroupTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaGroupTarget.java
@@ -67,7 +67,7 @@ public class JavaGroupTarget extends GroupTarget {
     @Override
     public void finish() throws GeneratorException {
         // Complete group object
-        typeBuilder.addJavadoc(getGroup().getGroupTitle() + ": API endpoints for " + getGroup().getGroup() + " group.\n&copy; 2018 Onshape Inc.\n")
+        typeBuilder.addJavadoc(getGroup().getGroupTitle() + ": API endpoints for " + getGroup().getGroup() + " group.\n&copy; 2018-Present Onshape Inc.\n")
                 .addMethod(MethodSpec.constructorBuilder()
                         .addParameter(ClassName.get("com.onshape.api", "Onshape"), "onshape")
                         .addStatement("this.onshape = onshape")

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaLibraryTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaLibraryTarget.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -141,7 +141,7 @@ public class JavaLibraryTarget extends LibraryTarget {
     public void finish(boolean commit) throws GeneratorException {
         // Add a method to get the build version
         typeBuilder.superclass(BaseClient.class)
-                .addJavadoc("Onshape API client class.\n&copy; 2018 Onshape Inc.\n")
+                .addJavadoc("Onshape API client class.\n&copy; 2018-Present Onshape Inc.\n")
                 .addField(FieldSpec
                         .builder(OnshapeVersion.class, "buildVersion", Modifier.FINAL, Modifier.PRIVATE)
                         .initializer("new $T($S, $S, $S)",

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/model/Endpoint.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/model/Endpoint.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -121,7 +121,7 @@ public class Endpoint {
     }
 
     @JsonIgnore
-    public Endpoint merge(Endpoint other) {
+    public Endpoint merge(Endpoint other, boolean add) {
         Endpoint out = new Endpoint();
         out.type = type;
         out.url = url;
@@ -132,22 +132,22 @@ public class Endpoint {
         out.groupTitle = groupTitle;
         out.version = version;
         out.permissions = permissions;
-        out.parameters = parameters.merge(other.parameters);
-        out.headers = headers.merge(other.headers);
-        out.error = error.merge(other.error);
-        out.success = success.merge(other.success);
+        out.parameters = parameters.merge(other.parameters, add);
+        out.headers = headers.merge(other.headers, add);
+        out.error = error.merge(other.error, add);
+        out.success = success.merge(other.success, add);
         return out;
     }
 
-    public static Collection<Endpoint> merge(Collection<Endpoint> endpoints1, Collection<Endpoint> endpoints2) {
+    public static Collection<Endpoint> merge(Collection<Endpoint> endpoints1, Collection<Endpoint> endpoints2, boolean add) {
         Map<String, Endpoint> map = Maps.newLinkedHashMap();
         endpoints1.forEach((endpoint) -> {
             map.put(endpoint.getName(), endpoint);
         });
         endpoints2.forEach((endpoint) -> {
             if (map.containsKey(endpoint.getName())) {
-                map.put(endpoint.getName(), map.get(endpoint.getName()).merge(endpoint));
-            } else {
+                map.put(endpoint.getName(), map.get(endpoint.getName()).merge(endpoint, add));
+            } else if (add) {
                 map.put(endpoint.getName(), endpoint);
             }
         });

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/model/Example.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/model/Example.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/model/Field.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/model/Field.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,8 +25,9 @@ package com.onshape.api.generator.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
+import com.google.common.collect.Maps;
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Represents a single field, either as a path parameter, query parameter,
@@ -85,9 +86,18 @@ public class Field {
         return out;
     }
 
-    public static Collection<Field> merge(Collection<Field> fields1, Collection<Field> fields2) {
-        Collection<Field> out = new ArrayList<>(fields1);
-        out.addAll(fields2);
-        return out;
+    public static Collection<Field> merge(Collection<Field> fields1, Collection<Field> fields2, boolean add) {
+        Map<String, Field> map = Maps.newLinkedHashMap();
+        fields1.forEach((field) -> {
+            map.put(field.getField(), field);
+        });
+        fields2.forEach((field) -> {
+            if (add) {
+                map.put(field.getField(), field);
+            } else {
+                map.remove(field.getField());
+            }
+        });
+        return map.values();
     }
 }

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/model/FieldMap.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/model/FieldMap.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,15 +49,15 @@ public class FieldMap {
         return examples;
     }
     
-    public FieldMap merge(FieldMap other) {
+    public FieldMap merge(FieldMap other, boolean add) {
         FieldMap out = new FieldMap();
         out.examples.addAll(examples);
         out.examples.addAll(other.examples);
         out.fields.putAll(fields);
         other.fields.keySet().forEach((field) -> {
             if(out.fields.containsKey(field)) {
-                out.fields.put(field, Field.merge(out.fields.get(field), other.fields.get(field)));
-            } else {
+                out.fields.put(field, Field.merge(out.fields.get(field), other.fields.get(field), add));
+            } else if (add) {
                 out.fields.put(field, other.fields.get(field));
             }
         });

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/model/Group.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/model/Group.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -62,23 +62,23 @@ public class Group {
     }
 
     @JsonIgnore
-    public Group merge(Group other) {
+    public Group merge(Group other, boolean add) {
         Group out = new Group();
         out.group = group;
         out.groupTitle = groupTitle;
-        out.endpoints = Endpoint.merge(endpoints, other.endpoints);
+        out.endpoints = Endpoint.merge(endpoints, other.endpoints, add);
         return out;
     }
 
-    public static Group[] merge(Group[] groups1, Group[] groups2) {
+    public static Group[] merge(Group[] groups1, Group[] groups2, boolean add) {
         Map<String, Group> map = Maps.newLinkedHashMap();
         for (Group group : groups1) {
             map.put(group.getGroup(), group);
         }
         for (Group group : groups2) {
             if (map.containsKey(group.getGroup())) {
-                map.put(group.getGroup(), map.get(group.getGroup()).merge(group));
-            } else {
+                map.put(group.getGroup(), map.get(group.getGroup()).merge(group, add));
+            } else if (add) {
                 map.put(group.getGroup(), group);
             }
         }

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/model/Permission.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/model/Permission.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/targets/EndpointTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/targets/EndpointTarget.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/targets/GroupTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/targets/GroupTarget.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/targets/LibraryTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/targets/LibraryTarget.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/tests/TestsEndpointTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/tests/TestsEndpointTarget.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/tests/TestsGroupTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/tests/TestsGroupTarget.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/tests/TestsLibraryTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/tests/TestsLibraryTarget.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 Onshape Inc.
+ * Copyright 2018-Present Onshape Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/onshape-java/api-generator/src/main/resources/endpoints.augment.json
+++ b/onshape-java/api-generator/src/main/resources/endpoints.augment.json
@@ -127,5 +127,67 @@
                 }
             }
         ]
+    },
+    {
+        "group": "PartStudios",
+        "endpoints": [
+            {
+                "name": "getFeatures",
+                "success": {
+                    "fields": {
+                        "Response": [{
+                                "group": "Response",
+                                "type": "Object",
+                                "optional": false,
+                                "field": "features.0",
+                                "defaultValue": null,
+                                "description": "The serialized feature definition"
+                            }, {
+                                "group": "Response",
+                                "type": "Object",
+                                "optional": false,
+                                "field": "featureStates",
+                                "defaultValue": null,
+                                "description": "Map of feature state information"
+                            }, {
+                                "group": "Response",
+                                "type": "String",
+                                "optional": false,
+                                "field": "featuresStates.key",
+                                "defaultValue": null,
+                                "description": "Feature id"
+                            }, {
+                                "group": "Response",
+                                "type": "Object",
+                                "optional": false,
+                                "field": "imports.0",
+                                "defaultValue": null,
+                                "description": "The import definition"
+                            }, {
+                                "group": "Response",
+                                "type": "String",
+                                "optional": false,
+                                "field": "imports.0.namespace",
+                                "defaultValue": null,
+                                "description": "The namespace for an import"
+                            }, {
+                                "group": "Response",
+                                "type": "String",
+                                "optional": false,
+                                "field": "imports.0.path",
+                                "defaultValue": null,
+                                "description": "The path for an import"
+                            }, {
+                                "group": "Response",
+                                "type": "String",
+                                "optional": false,
+                                "field": "imports.0.version",
+                                "defaultValue": null,
+                                "description": "The version for an import"
+                            }]
+                    }
+                }
+            }
+        ]
     }
 ]

--- a/onshape-java/api-generator/src/main/resources/endpoints.augment.json
+++ b/onshape-java/api-generator/src/main/resources/endpoints.augment.json
@@ -125,6 +125,63 @@
                             }]
                     }
                 }
+            },
+            {
+                "name": "getFeatures",
+                "success": {
+                    "fields": {
+                        "Response": [{
+                                "group": "Response",
+                                "type": "Object",
+                                "optional": false,
+                                "field": "features.0",
+                                "defaultValue": null,
+                                "description": "The serialized feature definition"
+                            }, {
+                                "group": "Response",
+                                "type": "Object",
+                                "optional": false,
+                                "field": "featureStates",
+                                "defaultValue": null,
+                                "description": "Map of feature state information"
+                            }, {
+                                "group": "Response",
+                                "type": "String",
+                                "optional": false,
+                                "field": "featureStates.key",
+                                "defaultValue": null,
+                                "description": "Feature id"
+                            }, {
+                                "group": "Response",
+                                "type": "Object",
+                                "optional": false,
+                                "field": "imports.0",
+                                "defaultValue": null,
+                                "description": "The import definition"
+                            }, {
+                                "group": "Response",
+                                "type": "String",
+                                "optional": false,
+                                "field": "imports.0.namespace",
+                                "defaultValue": null,
+                                "description": "The namespace for an import"
+                            }, {
+                                "group": "Response",
+                                "type": "String",
+                                "optional": false,
+                                "field": "imports.0.path",
+                                "defaultValue": null,
+                                "description": "The path for an import"
+                            }, {
+                                "group": "Response",
+                                "type": "String",
+                                "optional": false,
+                                "field": "imports.0.version",
+                                "defaultValue": null,
+                                "description": "The version for an import"
+                            }]
+                    }
+                }
             }
         ]
     },
@@ -153,7 +210,7 @@
                                 "group": "Response",
                                 "type": "String",
                                 "optional": false,
-                                "field": "featuresStates.key",
+                                "field": "featureStates.key",
                                 "defaultValue": null,
                                 "description": "Feature id"
                             }, {

--- a/onshape-java/api-generator/src/main/resources/endpoints.delete.json
+++ b/onshape-java/api-generator/src/main/resources/endpoints.delete.json
@@ -1,5 +1,34 @@
 [
     {
+        "group": "Assemblies",
+        "endpoints": [
+            {
+                "name": "getFeatures",
+                "success": {
+                    "fields": {
+                        "Response": [{
+                                "field": "features.0.message"
+                            }, {
+                                "field": "featureStates.0"
+                            }, {
+                                "field": "featureStates.0.key"
+                            }, {
+                                "field": "featureStates.0.value"
+                            }, {
+                                "field": "imports.0.message"
+                            }, {
+                                "field": "imports.0.message.namespace"
+                            }, {
+                                "field": "imports.0.message.path"
+                            }, {
+                                "field": "imports.0.message.version"
+                            }]
+                    }
+                }
+            }
+        ]
+    },
+    {
         "group": "PartStudios",
         "endpoints": [
             {
@@ -9,9 +38,11 @@
                         "Response": [{
                                 "field": "features.0.message"
                             }, {
+                                "field": "featureStates.0"
+                            }, {
                                 "field": "featureStates.0.key"
                             }, {
-                                "field": "featuresStates.0.value"
+                                "field": "featureStates.0.value"
                             }, {
                                 "field": "imports.0.message"
                             }, {

--- a/onshape-java/api-generator/src/main/resources/endpoints.delete.json
+++ b/onshape-java/api-generator/src/main/resources/endpoints.delete.json
@@ -1,0 +1,29 @@
+[
+    {
+        "group": "PartStudios",
+        "endpoints": [
+            {
+                "name": "getFeatures",
+                "success": {
+                    "fields": {
+                        "Response": [{
+                                "field": "features.0.message"
+                            }, {
+                                "field": "featureStates.0.key"
+                            }, {
+                                "field": "featuresStates.0.value"
+                            }, {
+                                "field": "imports.0.message"
+                            }, {
+                                "field": "imports.0.message.namespace"
+                            }, {
+                                "field": "imports.0.message.path"
+                            }, {
+                                "field": "imports.0.message.version"
+                            }]
+                    }
+                }
+            }
+        ]
+    }
+]

--- a/onshape-java/api-generator/src/main/resources/java/README.md
+++ b/onshape-java/api-generator/src/main/resources/java/README.md
@@ -4,7 +4,7 @@ Onshape API Java Client
 This is a Java library for accessing the Onshape APIs from both cloud and
 desktop applications.
 
-Copyright 2018 Onshape Inc.
+Copyright 2018-Present Onshape Inc.
 
 [Javadoc documentation](http://onshape-public.github.io/java-client/index.html?com/onshape/api/Onshape.html)
 


### PR DESCRIPTION
Correctly create entity containing Blob for file uploads (see https://github.com/onshape-public/java-client/issues/21), also set fileContentLength field based on blob size.

Re-add support for Onshape v1 JSON format (removed in #32) as sometimes used on empty responses, and send array of acceptable response types, including "*/*" in the case of binary responses (see https://github.com/onshape-public/java-client/issues/22).