### PR TITLE
Further fixes to file upload methods

### DIFF
--- a/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
@@ -87,7 +87,6 @@ import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.media.multipart.Boundary;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
-import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
@@ -423,7 +422,7 @@ public class BaseClient {
                         }
                     } else if (Blob.class.equals(type.getDeclaredFields()[0].getType())) {
                         try {
-                            Blob blob = new Blob(input);
+                            Blob blob = new Blob(input, response.getHeaderString("Content-Disposition"));
                             Constructor<T> constructor = type.getDeclaredConstructor();
                             constructor.setAccessible(true);
                             T out = constructor.newInstance();
@@ -565,7 +564,8 @@ public class BaseClient {
                 multipart.bodyPart(new FileDataBodyPart("file", (File) fileField.get(payload), MediaType.WILDCARD_TYPE));
             } else if (blobField != null) {
                 blobField.setAccessible(true);
-                multipart.bodyPart(new FormDataBodyPart(FormDataContentDisposition.name("file").build(),
+                multipart.bodyPart(new FormDataBodyPart(
+                        ((AbstractBlob) blobField.get(payload)).getFormDataContentDisposition("file"),
                         ((AbstractBlob) blobField.get(payload)).getData(), MediaType.WILDCARD_TYPE));
             }
         } catch (IllegalArgumentException | IllegalAccessException ex) {

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/AbstractBlob.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/AbstractBlob.java
@@ -30,6 +30,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Date;
+import org.glassfish.jersey.media.multipart.ContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 
 /**
  * Base class for binary data.
@@ -38,18 +41,83 @@ import java.nio.file.Path;
  */
 public abstract class AbstractBlob {
 
+    private final ContentDisposition contentDisposition;
+
+    protected AbstractBlob(ContentDisposition contentDisposition) {
+        this.contentDisposition = contentDisposition;
+    }
+
+    /**
+     * Get the contents of this Blob as a byte array
+     * @return byte[] of contents
+     */
     public abstract byte[] getData();
 
+    /**
+     * Write the contents of this Blob to a File
+     * 
+     * @param f File to write to
+     * @throws IOException If writing fails
+     */
     public final void toFile(File f) throws IOException {
         toFile(f.toPath());
     }
 
+    /**
+     * Write the contents of this Blob to a File
+     * 
+     * @param p Path to write to
+     * @throws IOException If writing fails
+     */
     public final void toFile(Path p) throws IOException {
         Files.write(p, getData());
     }
 
+    /**
+     * Get an InputStream to read the contents of this Blob
+     * @return An InputStream
+     */
     public final InputStream toInputStream() {
         return new ByteArrayInputStream(getData());
+    }
+
+    /**
+     * Get the name, if any, associated with this Blob
+     * @return String of filename or null
+     */
+    public final String getFileName() {
+        return contentDisposition.getFileName();
+    }
+
+    /**
+     * Get the creation date, if any, associated with this Blob
+     * @return Date of creation or null
+     */
+    public final Date getCreationDate() {
+        return contentDisposition.getCreationDate();
+    }
+
+    /**
+     * Get the last modified date, if any, associated with this Blob
+     * @return Date of modification or null
+     */
+    public final Date getModificationDate() {
+        return contentDisposition.getModificationDate();
+    }
+
+    /**
+     * Create a FormDataContentDisposition suitable for submitting this Blob
+     * as part of a multipart form submission
+     * 
+     * @param name Name of the blob field
+     * @return A FormDataContentDisposition
+     */
+    public final FormDataContentDisposition getFormDataContentDisposition(String name) {
+        return FormDataContentDisposition.name(name).creationDate(contentDisposition.getCreationDate())
+                .modificationDate(contentDisposition.getModificationDate())
+                .fileName(contentDisposition.getFileName())
+                .readDate(contentDisposition.getReadDate())
+                .size(contentDisposition.getSize()).build();
     }
 
     protected static byte[] fromFile(File file) throws IOException {

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/Base64Encoded.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/Base64Encoded.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Objects;
+import org.glassfish.jersey.media.multipart.ContentDisposition;
 
 /**
  * Represents binary data encoded as Base64. This is serialized as a String in
@@ -61,10 +62,11 @@ public class Base64Encoded extends AbstractBlob {
     }
 
     public Base64Encoded(byte[] data) {
-        this.base64String = Base64.getEncoder().encodeToString(data);
+        this(Base64.getEncoder().encodeToString(data));
     }
 
     public Base64Encoded(String base64String) {
+        super(ContentDisposition.type("attachement").build());
         this.base64String = base64String;
     }
 

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/ErrorResponse.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/ErrorResponse.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020 Onshape Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.onshape.api.types;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Response from API method with error message
+ *
+ * @author Peter Harman peter.harman@cae.tech
+ */
+public class ErrorResponse extends AbstractResponseObject {
+
+    @JsonProperty
+    private String message;
+    @JsonProperty
+    private Integer status;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+}


### PR DESCRIPTION
See https://github.com/onshape-public/java-client/issues/21
* Capture error message from server where there is one, and use in thrown exception to give better diagnostics
* Capture filename and other information from Content-Disposition header in downloads
* Capture filename and other information from File/Path objects used to create Blobs for uploads
* Generate a FormDataContentDisposition for uploaded Blobs in order to pass filename to server to help server identify file format of upload
