### PR TITLE
Try alternate logic for identifying arrays

### DIFF
--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
@@ -371,7 +371,7 @@ public class JavaEndpointTarget extends EndpointTarget {
             Collection<Field> fields, boolean builder) throws GeneratorException, GeneratorException {
         Map<Field, TypeName> types = Maps.newLinkedHashMap();
         for (Field field : fields) {
-            if (field.getField().startsWith(prefix) && !field.getField().equals(prefix + "0")) {
+            if (field.getField().startsWith(prefix) && !field.getField().endsWith(".0")) {
                 String fieldName = field.getField().substring((field.getField().startsWith(prefix + "0.") ? 2 : 0) + prefix.length());
                 if (fieldName.indexOf('.') == -1) {
                     Class<?> fieldType = JavaLibraryTarget.guessClass(field.getType());


### PR DESCRIPTION
There will be a new api coming out defined as
```
    /**
     * @api {post} /appelements/d/:did/[wvm]/:wvm/e/:eid/content/jsonpaths Get JSON tree data via paths
     * @apiName getJsonPaths
     * @apiDescription Gets the portions of a JSON tree at a workspace/microversion/version, as specified by JsonPaths
     * @apiGroup AppElements
     *
     * @apiVersion 2.0.0
     * @apiPermission public
     * @apiPermission OAuth2Read
     *
     * @apiUse applicationTypeJSONHeader
     * @apiUse v2RequestJSONHeader
     *
     * @apiUse DWVMEPathParam
     * @apiParam (QueryParam) {String} [transactionId=] Id of the transaction in which the JSON should be retrieved
     *           Valid only when used with a workspaceId
     * @apiParam (QueryParam) {String} [changeId=] Id of the change at which the JSON should be retrieved Valid only
     *           when used with a workspaceId
     * @apiParam (Body) {String[]} paths lists of path in the JsonPath format
     *
     * @apiSuccess (Response) {String} changeId Id of the change at which the JSON was actually retrieved
     * @apiSuccess (Response) {Object[][]} results Retrieved data
     * @apiSuccess (Response) {Object[]} results.0 A list of matches corresponding to one of the input paths
     * @apiSuccess (Response) {Object} results.0.0 A single match
     * @apiSuccess (Response) {Object} results.0.0.node The actual JSON corresponding to the path - can be any type, not
     *             just Object
     * @apiSuccess (Response) {String} results.0.0.definiteJsonPath The full path to the match, as a JsonPath
     *
     */
```

which generates endpoint json
```
          "fields": {
            "Response": [
              {
                "group": "Response",
                "type": "String",
                "optional": false,
                "field": "changeId",
                "description": "Id of the change at which the JSON was actually retrieved"
              },
              {
                "group": "Response",
                "type": "Object[][]",
                "optional": false,
                "field": "results",
                "description": "Retrieved data"
              },
              {
                "group": "Response",
                "type": "Object[]",
                "optional": false,
                "field": "results.0",
                "description": "A list of matches corresponding to one of the input paths"
              },
              {
                "group": "Response",
                "type": "Object",
                "optional": false,
                "field": "results.0.0",
                "description": "A single match"
              },
              {
                "group": "Response",
                "type": "Object",
                "optional": false,
                "field": "results.0.0.node",
                "description": "The actual JSON corresponding to the path - can be any type, not\n            just Object"
              },
              {
                "group": "Response",
                "type": "String",
                "optional": false,
                "field": "results.0.0.definiteJsonPath",
                "description": "The full path to the match, as a JsonPath"
              }
            ]
```

The `"field": "results.0.0"` in particular seems to cause problem with the api-generator, which has never before encountered 2D arrays.  The generator used to try to identify array fields by seeing if their name was `{somePrefix}.0`, which only works for 1-dimensional arrays.  The new logic attempts to identify arrays by seeing if their name ends in `.0`.