### PR TITLE
Fixed requests of thumbnail image data

### DIFF
--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/Blob.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/Blob.java
@@ -103,11 +103,11 @@ public final class Blob extends AbstractBlob {
         this(fromInputStream(is), parseHeader(contentDispositionHeader));
     }
 
-    static ContentDisposition parseHeader(String contentDispositionHeader) throws IOException {
+    static ContentDisposition parseHeader(String contentDispositionHeader) {
         try {
             return new ContentDisposition(contentDispositionHeader);
         } catch (ParseException ex) {
-            throw new IOException("Failed to parse Content-Disposition header" + contentDispositionHeader, ex);
+            return ContentDisposition.type("attachment").build();
         }
     }
 

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/OnshapeDocument.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/OnshapeDocument.java
@@ -136,7 +136,7 @@ public class OnshapeDocument {
     /**
      * Get the base URL, typically https://cad.onshape.com
      *
-     * @return
+     * @return Base URL as a String
      */
     public String getBaseURL() {
         return baseURL;

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
@@ -71,6 +71,8 @@ import tech.cae.javabard.GetterSpec;
  */
 public class JavaEndpointTarget extends EndpointTarget {
 
+    private final Set<String> blobNames = Sets.newHashSet("file", "data", "image");
+
     public JavaEndpointTarget(GroupTarget groupTarget, Endpoint endpoint) {
         super(groupTarget, endpoint);
     }
@@ -540,7 +542,7 @@ public class JavaEndpointTarget extends EndpointTarget {
                             TypeName ref = createLocalType("com.onshape.api.responses", name, typeName, name + ".", allResponseFields, false);
                             fieldType = ArrayTypeName.of(ref);
                         }
-                    } else if (field.getField().equals("file") && t.equals(Base64Encoded.class) && allResponseFields.size() == 1) {
+                    } else if (blobNames.contains(field.getField()) && allResponseFields.size() == 1) {
                         // An object with single field called "file" is treated differently by the client, as the response is just the File content
                         fieldType = JavaLibraryTarget.getTypeName(Blob.class);
                     } else {

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaLibraryTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaLibraryTarget.java
@@ -102,7 +102,7 @@ public class JavaLibraryTarget extends LibraryTarget {
         if ("public".equals(name)) {
             return "isPublic";
         }
-        return name.replace('-', '_');
+        return name.replace('-', '_').replace("[]", "");
     }
 
     @Override


### PR DESCRIPTION
Requests to GetThumbnailWithSize methods were failing as a Json response was expected. Fixed this by adding "image" as a possible name of a Blob field.

Allowed creation of Blob type without needing a Content-Disposition header as this is not returned by GetThumbnailWithSize methods.

Fixed bug from recent introduction of a field called "target[]" in API spec.

Set accept header as a wildcard in case of using InputStreamWithHeaders so that this can work with Json or Binary responses.