### PR TITLE
Support for [wm] and [vm] segments in method URLs 

### DIFF
--- a/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/base/BaseClient.java
@@ -662,15 +662,11 @@ public class BaseClient {
         if (path.startsWith("/")) {
             uriBuilder = UriBuilder.fromUri(baseURL + "/api" + path
                     .replaceAll(":([a-zA-Z][a-zA-Z0-9]*)", "{$1}")
-                    .replace("[wvm]", "{wvmType}")
-                    .replace("[wv]", "{wvType}")
-                    .replace("[cu]", "{cuType}"));
+                    .replaceAll("\\[([a-z]+)\\]", "{$1Type}"));
         } else {
             uriBuilder = UriBuilder.fromUri(path
                     .replaceAll(":([a-zA-Z][a-zA-Z0-9]*)", "{$1}")
-                    .replace("[wvm]", "{wvmType}")
-                    .replace("[wv]", "{wvType}")
-                    .replace("[cu]", "{cuType}"));
+                    .replaceAll("\\[([a-z]+)\\]", "{$1Type}"));
         }
         queryParameters.entrySet().stream().filter((queryParameter) -> (queryParameter.getValue() != null))
                 .forEachOrdered((queryParameter) -> {

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/OnshapeDocument.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/OnshapeDocument.java
@@ -23,6 +23,7 @@
  */
 package com.onshape.api.types;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.onshape.api.exceptions.OnshapeException;
 import java.util.Objects;
@@ -174,6 +175,7 @@ public class OnshapeDocument {
      *
      * @return wv or null if no workspace or version
      */
+    @JsonIgnore
     public WV getWV() {
         if (wvm == null || wvm == WVM.Microversion) {
             return null;
@@ -187,10 +189,47 @@ public class OnshapeDocument {
     }
 
     /**
+     * Gets the choice of WM (Workspace, Microversion)
+     *
+     * @return wm or null if no workspace or microversion
+     */
+    @JsonIgnore
+    public WM getWM() {
+        if (wvm == null || wvm == WVM.Version) {
+            return null;
+        }
+        switch (wvm) {
+            case Workspace:
+                return WM.Workspace;
+            default:
+                return WM.Microversion;
+        }
+    }
+
+    /**
+     * Gets the choice of VM (Version, Microversion)
+     *
+     * @return vm or null if no version or microversion
+     */
+    @JsonIgnore
+    public VM getVM() {
+        if (wvm == null || wvm == WVM.Workspace) {
+            return null;
+        }
+        switch (wvm) {
+            case Version:
+                return VM.Version;
+            default:
+                return VM.Microversion;
+        }
+    }
+
+    /**
      * Gets either Workspace, Version or Microversion, depending on WVM variable
      *
      * @return An id, or null if none available
      */
+    @JsonIgnore
     public String getWVMId() {
         if (wvm == null) {
             return null;
@@ -210,6 +249,7 @@ public class OnshapeDocument {
      *
      * @return An id, or null if none available
      */
+    @JsonIgnore
     public String getWVId() {
         if (wvm == null || wvm == WVM.Microversion) {
             return null;
@@ -219,6 +259,42 @@ public class OnshapeDocument {
                 return workspaceId;
             default:
                 return versionId;
+        }
+    }
+
+    /**
+     * Gets either Workspace or Microversion, depending on WM variable
+     *
+     * @return An id, or null if none available
+     */
+    @JsonIgnore
+    public String getWMId() {
+        if (wvm == null || wvm == WVM.Version) {
+            return null;
+        }
+        switch (wvm) {
+            case Workspace:
+                return workspaceId;
+            default:
+                return microversionId;
+        }
+    }
+
+    /**
+     * Gets either Version or Microversion, depending on VM variable
+     *
+     * @return An id, or null if none available
+     */
+    @JsonIgnore
+    public String getVMId() {
+        if (wvm == null || wvm == WVM.Workspace) {
+            return null;
+        }
+        switch (wvm) {
+            case Version:
+                return versionId;
+            default:
+                return microversionId;
         }
     }
 

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/VM.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/VM.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Onshape Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.onshape.api.types;
+
+/**
+ * Enumeration to choose whether identifier represents Version or Microversion.
+ *
+ * @author Peter Harman peter.harman@cae.tech
+ */
+public enum VM {
+    Version,
+    Microversion;
+
+    @Override
+    public String toString() {
+        return name().substring(0, 1).toLowerCase();
+    }
+
+}

--- a/onshape-java/api-base/src/main/java/com/onshape/api/types/WM.java
+++ b/onshape-java/api-base/src/main/java/com/onshape/api/types/WM.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Onshape Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.onshape.api.types;
+
+/**
+ * Enumeration to choose whether identifier represents Workspace or Microversion.
+ *
+ * @author Peter Harman peter.harman@cae.tech
+ */
+public enum WM {
+    Workspace,
+    Microversion;
+
+    @Override
+    public String toString() {
+        return name().substring(0, 1).toLowerCase();
+    }
+
+}

--- a/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
+++ b/onshape-java/api-generator/src/main/java/com/onshape/api/generator/java/JavaEndpointTarget.java
@@ -224,6 +224,36 @@ public class JavaEndpointTarget extends EndpointTarget {
                             javadoc3.append("\n@param wvType Type of Workspace or Version\n");
                             i++;
                             break;
+                        case "wm":
+                            if (i > 0) {
+                                callStatement.append(", ");
+                                callStatement2.append(", ");
+                                callStatement3.append(", ");
+                            }
+                            callStatement.append("\"wmType\", wmType");
+                            callStatement2.append("\"wmType\", document.getWM()");
+                            callStatement3.append("\"wmType\", wmType");
+                            callBuilder.addParameter(ClassName.get("com.onshape.api.types", "WM"), "wmType");
+                            javadoc.append("\n@param wmType Type of Workspace or Microversion\n");
+                            callBuilder3.addParameter(ClassName.get("com.onshape.api.types", "WM"), "wmType");
+                            javadoc3.append("\n@param wmType Type of Workspace or Microversion\n");
+                            i++;
+                            break;
+                        case "vm":
+                            if (i > 0) {
+                                callStatement.append(", ");
+                                callStatement2.append(", ");
+                                callStatement3.append(", ");
+                            }
+                            callStatement.append("\"vmType\", vmType");
+                            callStatement2.append("\"vmType\", document.getVM()");
+                            callStatement3.append("\"vmType\", vmType");
+                            callBuilder.addParameter(ClassName.get("com.onshape.api.types", "VM"), "vmType");
+                            javadoc.append("\n@param vmType Type of Version or Microversion\n");
+                            callBuilder3.addParameter(ClassName.get("com.onshape.api.types", "VM"), "vmType");
+                            javadoc3.append("\n@param vmType Type of Version or Microversion\n");
+                            i++;
+                            break;
                         case "oid":
                             if (i > 0) {
                                 callStatement.append(", ");
@@ -273,6 +303,14 @@ public class JavaEndpointTarget extends EndpointTarget {
                             break;
                         case "wv":
                             callStatement2.append("\"wv\", document.getWVId()");
+                            includeCall2 = true;
+                            break;
+                        case "wm":
+                            callStatement2.append("\"wm\", document.getWMId()");
+                            includeCall2 = true;
+                            break;
+                        case "vm":
+                            callStatement2.append("\"vm\", document.getVMId()");
                             includeCall2 = true;
                             break;
                         case "wid":


### PR DESCRIPTION
The Java client supported [wvm] and [wv] segments in method URLs, as enumerations of Workspace/Version/Microversion and Workspace/Version. This PR adds support for [wm] and [vm] segments, with correct substitution in URLs and with dedicated enumerations.